### PR TITLE
Improve Syllable Text UX on Create Pitch Art page (Task 10)

### DIFF
--- a/frontend/src/Create/TargetPitchBar.tsx
+++ b/frontend/src/Create/TargetPitchBar.tsx
@@ -175,10 +175,23 @@ export class TargetPitchBar extends Component<TargetPitchBarProps, State> {
     this.initialX = 0;
     this.initialY = 0;
     this.selectedContourElements = [];
+    this.handlePitchArtDotClicked = this.handlePitchArtDotClicked.bind(this);
+  }
+  
+  componentDidMount() {
+    window.addEventListener('pitchArtDotClicked', this.handlePitchArtDotClicked as EventListener);
   }
 
   componentWillUnmount() {
     document.removeEventListener('click', this.handleDocumentClick);
+    window.removeEventListener('pitchArtDotClicked', this.handlePitchArtDotClicked as EventListener);
+  }
+
+  handlePitchArtDotClicked(event: CustomEvent) {
+    const { speakerIndex, letterIndex } = event.detail;
+    if (speakerIndex === this.props.speakerIndex && letterIndex >= 0) {
+      this.targetPitchSelected(letterIndex);
+    }
   }
 
   resetAllLettersEvent() {
@@ -243,7 +256,11 @@ export class TargetPitchBar extends Component<TargetPitchBarProps, State> {
   }
 
   targetPitchSelected(letterIndex: number) {
-    this.setState({ selectedIndex: letterIndex });
+    this.setState({ selectedIndex: letterIndex }, () => {
+      if (letterIndex >= 0) {
+        this.setState({ showEditSyllableModal: true });
+      }
+    });
     this.props.targetPitchSelected(letterIndex);
   }
 
@@ -357,6 +374,7 @@ export class TargetPitchBar extends Component<TargetPitchBarProps, State> {
             ].t1
           }
           saveSyllable={this.saveSyllable}
+          removeSyllable={this.handleRemoveFromModal}
           handleClose={this.handleCloseEditSyllableModal}
         ></UpdateSyllable>
       );
@@ -382,6 +400,18 @@ export class TargetPitchBar extends Component<TargetPitchBarProps, State> {
     this.setState({
       showEditSyllableModal: true,
     });
+  };
+
+  // Handle remove action triggered from the Selected Range popup
+  handleRemoveFromModal = () => {
+    this.handleCloseEditSyllableModal();
+    const letters = this.props.speakers[this.props.speakerIndex].letters;
+    const letter = letters[this.state.selectedIndex];
+    if (letter != null && letter.isContour) {
+      this.setState({ showDeleteLetterModal: true });
+    } else {
+      this.removeLetterEvent();
+    }
   };
 
   removeSyllableEvent = () =>{

--- a/frontend/src/Create/UpdateSyllable.tsx
+++ b/frontend/src/Create/UpdateSyllable.tsx
@@ -50,6 +50,7 @@ export interface UpdateSyllableProps {
     currentT0: number;
     currentT1: number;
     saveSyllable: (syllable: string, t0: number, t1: number) => void;
+    removeSyllable?: () => void;
     handleClose: () => void;
 }
 
@@ -111,15 +112,15 @@ render() {
    
     return(
         <Dialog fullWidth={true} maxWidth="xs" open={this.props.showEditSyllableModal}
-                onClose={this.props.handleClose}aria-labelledby="form-dialog-title">
+                onClose={this.props.handleClose} aria-labelledby="form-dialog-title">
 
         <DialogTitle onClose={this.props.handleClose} id="form-dialog-title">
-            <p>Syllable Details</p>
+            <p>Selected Range</p>
         </DialogTitle>
         <DialogContent>
         <div className="row">
           <div className="col s4">
-            <p>Syllable:</p>
+            <p>text:</p>
           </div>
           <div className="col s4">
             <input 
@@ -136,6 +137,13 @@ render() {
           
         </DialogContent>
         <DialogActions>
+            {this.props.removeSyllable && (
+              <button className="RemoveSyllable waves-effect waves-light btn globalbtn"
+                onClick={this.props.removeSyllable}
+                style={{ marginRight: "auto" }}>
+                  Remove
+              </button>
+            )}
             <button className="SaveSyllable waves-effect waves-light btn globalbtn"
             onClick={() => this.props.saveSyllable(this.state.currentSyllable, 
                             this.state.currentT0, this.state.currentT1)}>

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
@@ -47,6 +47,7 @@ interface Props {
 }
 
 export default class PitchArtGeometry extends React.Component<Props> {
+
     constructor(props: Props) {
         super(props);
         this.state = {
@@ -54,7 +55,8 @@ export default class PitchArtGeometry extends React.Component<Props> {
             contextMenuX: 0,
             contextMenuY: 0,
             contextMenuSpeakerIndex: null,
-            contextMenuLetterIndex: null
+            contextMenuLetterIndex: null,
+            textOffsets: {},
         };
     }
 
@@ -278,12 +280,32 @@ export default class PitchArtGeometry extends React.Component<Props> {
                 const konvaFontSizeAsPixels = this.props.fontSize * 0.65;
                 const text = speaker.letters[i].syllable;
     
+                const textOffsetKey = `${speakerIndex}-${i}`;
+                const savedOffset = (this.state as any).textOffsets?.[textOffsetKey] || { dx: 0, dy: 0 };
+                const baseTextX = x - (konvaFontSizeAsPixels * text.length / 2.0);
+                const baseTextY = y + circleRadius * 1.9;
                 letterSyllables.push(
-                    <Text key={i}
-                          x={x - (konvaFontSizeAsPixels * text.length / 2.0)}
-                          y={y + circleRadius * 1.9}  // position text below the pitch circle
+                    <Text key={`text-${speakerIndex}-${i}`}
+                          x={baseTextX + savedOffset.dx}
+                          y={baseTextY + savedOffset.dy}
                           fontSize={this.props.fontSize}
-                          text={text}/>
+                          text={text}
+                          fill="#000"
+                          draggable={true}
+                          onDragEnd={(e) => {
+                              const node = e.target;
+                              const newDx = node.x() - baseTextX;
+                              const newDy = node.y() - baseTextY;
+                              this.setState((prev: any) => ({
+                                  textOffsets: {
+                                      ...prev.textOffsets,
+                                      [textOffsetKey]: { dx: newDx, dy: newDy },
+                                  },
+                              }));
+                          }}
+                          onMouseEnter={() => this.props.setPointerEnabled(true)}
+                          onMouseLeave={() => this.props.setPointerEnabled(false)}
+                    />
                 );
     
                 let circleFill = this.props.colorSchemes[speakerIndex].praatDotFillColor;
@@ -318,6 +340,10 @@ export default class PitchArtGeometry extends React.Component<Props> {
                                 onClick={(e) => {
                                     if (e.evt.button === 2) return;
                                     this.props.playSound(currPitch);
+                                    // notify Melody bar to select this segment
+                                    window.dispatchEvent(new CustomEvent('pitchArtDotClicked', {
+                                        detail: { speakerIndex, letterIndex: i }
+                                    }));
                                 }}
                                 onMouseEnter={() => this.props.setPointerEnabled(true)}
                                 onMouseLeave={() => this.props.setPointerEnabled(false)}


### PR DESCRIPTION
- Open Selected Range popup directly on Melody bar segment click (skip Edit Melody button)
- Renamed 'Syllable Details' to 'Selected Range' in popup title
- Renamed 'Syllable:' to 'text:' in popup label
- Added Remove button inside Selected Range popup
- Made syllable text labels draggable in Pitch Art canvas
- Click dot in Pitch Art selects corresponding segment on Melody bar and opens popup
- Zero changes to business logic, routing, or API calls