### PR TITLE
Multi-speaker Pitch Art: per-speaker tones, canvas labels, menu layout, adjustable dot sizes

### DIFF
--- a/frontend/src/Components/create/SaveAnalysisFirestore.tsx
+++ b/frontend/src/Components/create/SaveAnalysisFirestore.tsx
@@ -227,7 +227,7 @@ function SaveAnalysisFirestore({ analysis, saveThumbnail, data, callBacks,curren
     const collectionUuid = getCollectionUuidFromName(selectedCollection);
 
     if (word === undefined || wordTranslate === undefined || speakerName === undefined) {
-      NotificationManager.error("Invalid Spearker Name or Word or Word Translation !!!");
+      NotificationManager.error("Invalid Speaker Name or Word or Word Translation !!!");
     }
     else {
       const copyOfData = JSON.parse(JSON.stringify(data));

--- a/frontend/src/Create/AudioAnalysis.tsx
+++ b/frontend/src/Create/AudioAnalysis.tsx
@@ -942,7 +942,7 @@ export class AudioAnalysis extends React.Component<AudioAnalysisProps, State> {
     const { speakerName, word, wordTranslation } = this.props.speakers[this.props.speakerIndex];
 
     if (speakerName === undefined) {
-      this.props.setSpeakerName(this.props.speakerIndex, "Speaker");
+      this.props.setSpeakerName(this.props.speakerIndex, "");
     }
     if (word === undefined) {
       this.props.setWord(this.props.speakerIndex, "Word");

--- a/frontend/src/Create/CreatePitchArt.tsx
+++ b/frontend/src/Create/CreatePitchArt.tsx
@@ -92,6 +92,8 @@ interface State {
     showVerticallyCentered: boolean;
     showPitchArtLines: boolean;
     showLargeCircles: boolean;
+    averageDotSize: "S" | "M" | "L";
+    contourDotSize: "S" | "M" | "L";
     showTimeNormalization: boolean;
     showPitchScale: boolean;
     showPerceptualScale: boolean;
@@ -149,6 +151,8 @@ class CreatePitchArt extends React.Component<
         showVerticallyCentered: true,
         showPitchArtLines: true,
         showLargeCircles: true,
+        averageDotSize: "L",
+        contourDotSize: "S",
         showTimeNormalization: true,
         showPitchScale: false,
         showPerceptualScale: true,

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArt.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArt.tsx
@@ -127,8 +127,8 @@ class PitchArt extends React.Component<Props> {
           <button
             className="waves-effect waves-light btn globalbtn metilda-pitch-art-btn"
             disabled={
-              this.props.speakers.length !== 1 ||
-              this.props.speakers[0].letters.length === 0
+              this.props.speakers.length === 0 ||
+              !this.props.speakers.some((sp) => sp.letters.length > 0)
             }
             onClick={this.playPitchArt}
           >

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArt.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArt.tsx
@@ -26,6 +26,8 @@ interface Props {
   showVerticallyCentered: boolean;
   showPitchArtLines: boolean;
   showLargeCircles: boolean;
+  averageDotSize?: "S" | "M" | "L";
+  contourDotSize?: "S" | "M" | "L";
   showTimeNormalization: boolean;
   showPitchScale: boolean;
   showPerceptualScale: boolean;
@@ -103,6 +105,8 @@ class PitchArt extends React.Component<Props> {
         showVerticallyCentered={this.props.showVerticallyCentered}
         showPitchArtLines={this.props.showPitchArtLines}
         showLargeCircles={this.props.showLargeCircles}
+        averageDotSize={this.props.averageDotSize}
+        contourDotSize={this.props.contourDotSize}
         showTimeNormalization={this.props.showTimeNormalization}
         showPitchScale={this.props.showPitchScale}
         showPerceptualScale={this.props.showPerceptualScale}

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.scss
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.scss
@@ -1,3 +1,19 @@
 .metilda-audio-analysis-controls-list-item p {
   color: black;
 }
+
+@media (min-width: 1001px) {
+  .pitchart-desktop-layout {
+    display: flex !important;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
+  }
+
+  .pitchart-desktop-layout > .col.s5,
+  .pitchart-desktop-layout > .col.s7 {
+    float: none !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+}

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.tsx
@@ -7,6 +7,7 @@ import PitchArt from "./PitchArt";
 import "./PitchArtContainer.css";
 import PitchArtLegend from "./PitchArtLegend";
 import PitchArtToggle from "./PitchArtToggle";
+import PitchArtDotSizeSelect, { DotSize } from "./PitchArtDotSizeSelect";
 import { Popover, Backdrop, createTheme, Box } from "@material-ui/core"
 import * as DEFAULT from "../../constants/create";
 
@@ -72,6 +73,10 @@ class PitchArtContainer extends React.Component<Props, State> {
             this.onVerticallyCenterClick(isSelected);
         }
         this.props.updatePitchArtValue(inputName, isSelected);
+    }
+
+    dotSizeChanged = (inputName: string, value: DotSize) => {
+        this.props.updatePitchArtValue(inputName, value);
     }
 
     applyPitchRange = (minPitch: number, maxPitch: number) => {
@@ -165,13 +170,17 @@ class PitchArtContainer extends React.Component<Props, State> {
                 onText="Yes"
                 onChange={this.toggleChanged}
               />
-              <PitchArtToggle
-                label={"Circle Size"}
-                inputName={"showLargeCircles"}
-                isSelected={this.props.pitchArt.showLargeCircles}
-                offText="Small"
-                onText="Large"
-                onChange={this.toggleChanged}
+              <PitchArtDotSizeSelect
+                label="Average Dot Size"
+                inputName="averageDotSize"
+                value={this.props.pitchArt.averageDotSize}
+                onChange={this.dotSizeChanged}
+              />
+              <PitchArtDotSizeSelect
+                label="Contour Dot Size"
+                inputName="contourDotSize"
+                value={this.props.pitchArt.contourDotSize}
+                onChange={this.dotSizeChanged}
               />
               <PitchArtToggle
                 label={"Time Normalization"}
@@ -303,6 +312,8 @@ class PitchArtContainer extends React.Component<Props, State> {
                         showVerticallyCentered={this.props.pitchArt.showVerticallyCentered}
                         showPitchArtLines={this.props.pitchArt.showPitchArtLines}
                         showLargeCircles={this.props.pitchArt.showLargeCircles}
+                        averageDotSize={this.props.pitchArt.averageDotSize}
+                        contourDotSize={this.props.pitchArt.contourDotSize}
                         showTimeNormalization={this.props.pitchArt.showTimeNormalization}
                         showPitchScale={this.props.pitchArt.showPitchScale}
                         showPerceptualScale={this.props.pitchArt.showPerceptualScale}

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtContainer.tsx
@@ -286,7 +286,7 @@ class PitchArtContainer extends React.Component<Props, State> {
         return (
           <>
             {(windowWidth <= 1000) ? this.renderPopupOptionList() : <></>}
-            <div>
+            <div className={windowWidth > 1000 ? "pitchart-desktop-layout" : ""}>
                 {(windowWidth > 1000) ? this.renderOptionList() : <></>}
                 <div className="col s7" style={{ paddingTop: "15px"}}>
                     <PitchArt

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDotSizeSelect.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDotSizeSelect.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import "./PitchArtToggle.css";
+
+export type DotSize = "S" | "M" | "L";
+
+export interface PitchArtDotSizeSelectProps {
+    label: string;
+    inputName: string;
+    value: DotSize;
+    onChange: (inputName: string, value: DotSize) => void;
+    disabled?: boolean;
+}
+
+class PitchArtDotSizeSelect extends React.Component<PitchArtDotSizeSelectProps> {
+    handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        this.props.onChange(this.props.inputName, e.target.value as DotSize);
+    }
+
+    render() {
+        const selectId = `dotSize-${this.props.inputName}`;
+        return (
+            <div className="PitchArtToggle col s6">
+                <div className="PitchArtToggle-label">
+                    <label htmlFor={selectId}>{this.props.label}</label>
+                </div>
+                <div className="PitchArtToggle-toggle">
+                    <select
+                        id={selectId}
+                        className="browser-default"
+                        value={this.props.value}
+                        disabled={this.props.disabled}
+                        onChange={this.handleChange}
+                        aria-label={this.props.label}
+                    >
+                        <option value="S">Small</option>
+                        <option value="M">Medium</option>
+                        <option value="L">Large</option>
+                    </select>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default PitchArtDotSizeSelect;

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDrawingWindow.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDrawingWindow.tsx
@@ -59,6 +59,8 @@ export interface PitchArtDrawingWindowProps {
   showArtDesign: boolean;
   showPitchArtLines: boolean;
   showLargeCircles: boolean;
+  averageDotSize?: "S" | "M" | "L";
+  contourDotSize?: "S" | "M" | "L";
   showVerticallyCentered: boolean;
   showAccentPitch: boolean;
   showSyllableText: boolean;
@@ -220,6 +222,18 @@ export class PitchArtDrawingWindow extends React.Component<
     this.accentedCircleRadius = 30;
     this.pitchArtSoundLengthSeconds = 0.2;
     this.fontSize = 16;
+  }
+
+  private resolveDotRadius = (
+    size: "S" | "M" | "L" | undefined,
+    fallback: "S" | "M" | "L"
+  ): number => {
+    const effective = size || fallback;
+    switch (effective) {
+      case "S": return 8;
+      case "M": return 14;
+      case "L": return 20;
+    }
   }
 
   handlePlaySpeakerEvent = (e: Event) => {
@@ -949,6 +963,8 @@ export class PitchArtDrawingWindow extends React.Component<
             showPrevPitchValueLists={this.props.showPrevPitchValueLists}
             largeCircleRadius={this.largeCircleRadius}
             smallCircleRadius={this.smallCircleRadius}
+            averageCircleRadius={this.resolveDotRadius(this.props.averageDotSize, "L")}
+            contourCircleRadius={this.resolveDotRadius(this.props.contourDotSize, "S")}
             graphWidth={this.graphWidth}
             fontSize={this.fontSize}
             circleStrokeWidth={this.circleStrokeWidth}

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDrawingWindow.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtDrawingWindow.tsx
@@ -88,6 +88,7 @@ type MergedIndexesMap = {
 
 interface State {
   activePlayIndex: number;
+  activePlaySpeakerIndex: number;
   showNewImageModal: boolean;
   currentImageName: string;
   allAnalysisIds: any[];
@@ -184,6 +185,7 @@ export class PitchArtDrawingWindow extends React.Component<
     super(props);
     this.state = {
       activePlayIndex: -1,
+      activePlaySpeakerIndex: -1,
       showNewImageModal: false,
       allAnalysisIds: [],
       currentImageName: "",
@@ -220,15 +222,30 @@ export class PitchArtDrawingWindow extends React.Component<
     this.fontSize = 16;
   }
 
+  handlePlaySpeakerEvent = (e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    if (detail && typeof detail.speakerIndex === "number") {
+      this.playPitchArt(detail.speakerIndex);
+    }
+  };
+
   componentDidMount() {
     const stage = this.stageRef.current;
-    if (!stage) return;
+    if (stage) {
+      const container = stage.getStage().container();
+      container.addEventListener("contextmenu", (e) => {
+        e.preventDefault();
+      });
+    }
+    if (this.props.showDynamicContent) {
+      document.addEventListener("pitchArtPlaySpeaker", this.handlePlaySpeakerEvent);
+    }
+  }
 
-    const container = stage.getStage().container();
-
-    container.addEventListener("contextmenu", (e) => {
-      e.preventDefault();
-    });
+  componentWillUnmount() {
+    if (this.props.showDynamicContent) {
+      document.removeEventListener("pitchArtPlaySpeaker", this.handlePlaySpeakerEvent);
+    }
   }
 
   downloadImage = () => {
@@ -444,12 +461,30 @@ export class PitchArtDrawingWindow extends React.Component<
     });
   };
 
-  playPitchArt() {
-    if (this.props.speakers.length !== 1) {
+  playPitchArt(targetSpeakerIndex?: number) {
+    const hidden = this.state.hiddenSpeakerIndices || [];
+    const visibleSpeakers: Array<{ speakerIndex: number; letters: Letter[] }> =
+      targetSpeakerIndex !== undefined
+        ? (this.props.speakers[targetSpeakerIndex] &&
+           this.props.speakers[targetSpeakerIndex].letters.length > 0
+            ? [{
+                speakerIndex: targetSpeakerIndex,
+                letters: this.props.speakers[targetSpeakerIndex].letters,
+              }]
+            : [])
+        : this.props.speakers
+            .map((sp, i) => ({ speakerIndex: i, letters: sp.letters }))
+            .filter(({ speakerIndex, letters }) =>
+              !hidden.includes(speakerIndex) && letters.length > 0
+            );
+
+    if (visibleSpeakers.length === 0) {
       return;
     }
 
-    const letters: Letter[] = this.props.speakers[0].letters;
+    Tone.Transport.stop();
+    Tone.Transport.cancel();
+
     const env = new Tone.AmplitudeEnvelope({
       attack: 0.001,
       decay: 0.001,
@@ -463,38 +498,57 @@ export class PitchArtDrawingWindow extends React.Component<
       rolloff: -48,
     }).toMaster();
 
-    // var synth = new window.Tone.Synth().toMaster().chain(filter, env);
     const synth = new Tone.Synth().toMaster().chain(filter, env);
 
-    const tStart = letters.length > 0 ? letters[0].t0 : 0;
-    const tEnd = letters.length > 0 ? letters[letters.length - 1].t1 : 0;
-    const totalDuration = tEnd - tStart;
-    const n = letters.length;
     const showTimeNormalization = this.props.showTimeNormalization;
 
     interface PitchArtNote {
       time: number;
       index: number;
+      speakerIndex: number;
       duration: number;
       pitch: number;
     }
 
-    const notes = letters.map((item, index) => {
-      const time = showTimeNormalization && n > 1
-        ? (index / (n - 1)) * totalDuration
-        : item.t0 - tStart;
-      const duration = showTimeNormalization
-        ? Math.min(0.2, totalDuration / Math.max(1, n))
-        : item.t1 - item.t0;
-      return {
-        time,
-        duration,
-        pitch: item.pitch,
-        index,
-      } as PitchArtNote;
+    const SPEAKER_GAP_SECONDS = 0.4;
+    const notes: PitchArtNote[] = [];
+    let cumulativeOffset = 0;
+
+    for (const sp of visibleSpeakers) {
+      const letters = sp.letters;
+      const tStart = letters[0].t0;
+      const tEnd = letters[letters.length - 1].t1;
+      const totalDuration = tEnd - tStart;
+      const n = letters.length;
+
+      letters.forEach((item, index) => {
+        const time = showTimeNormalization && n > 1
+          ? (index / (n - 1)) * totalDuration
+          : item.t0 - tStart;
+        const duration = showTimeNormalization
+          ? Math.min(0.2, totalDuration / Math.max(1, n))
+          : item.t1 - item.t0;
+        notes.push({
+          time: cumulativeOffset + time,
+          duration,
+          pitch: item.pitch,
+          index,
+          speakerIndex: sp.speakerIndex,
+        });
+      });
+
+      const speakerEndTime = showTimeNormalization && n > 1 ? totalDuration : tEnd - tStart;
+      cumulativeOffset += speakerEndTime + SPEAKER_GAP_SECONDS;
+    }
+
+    notes.push({
+      time: cumulativeOffset,
+      duration: 1,
+      pitch: 1,
+      index: -1,
+      speakerIndex: -1,
     });
-    const endTime = showTimeNormalization && n > 1 ? totalDuration : tEnd - tStart;
-    notes.push({ time: endTime, duration: 1, pitch: 1, index: -1 });
+
     const controller = this;
 
     // @ts-ignore
@@ -502,7 +556,10 @@ export class PitchArtDrawingWindow extends React.Component<
       time: Encoding.Time,
       note: PitchArtNote
     ) {
-      controller.setState({ activePlayIndex: note.index });
+      controller.setState({
+        activePlayIndex: note.index,
+        activePlaySpeakerIndex: note.speakerIndex,
+      });
       if (note.index !== -1) {
         synth.triggerAttackRelease(note.pitch, note.duration, time);
       }
@@ -878,9 +935,8 @@ export class PitchArtDrawingWindow extends React.Component<
             setLetterPitch={this.props.setLetterPitch}
             colorSchemes={colorSchemes}
             playSound={this.playSound}
-            activePlayIndex={
-              this.props.speakers.length === 1 ? this.state.activePlayIndex : -1
-            }
+            activePlayIndex={this.state.activePlayIndex}
+            activePlaySpeakerIndex={this.state.activePlaySpeakerIndex}
             showDynamicContent={this.props.showDynamicContent}
             showArtDesign={this.props.showArtDesign}
             showPitchArtLines={this.props.showPitchArtLines}

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
@@ -11,6 +11,7 @@ interface Props {
     setLetterPitch: (speakerIndex: number, letterIndex: number, newPitch: number) => void;
     playSound: (pitch: number) => void;
     activePlayIndex: number;
+    activePlaySpeakerIndex: number;
     colorSchemes: ColorScheme[];
     showDynamicContent: boolean;
     showArtDesign: boolean;
@@ -57,6 +58,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
             contextMenuSpeakerIndex: null,
             contextMenuLetterIndex: null,
             textOffsets: {},
+            speakerLabelOffsets: {},
         };
     }
 
@@ -166,10 +168,52 @@ export default class PitchArtGeometry extends React.Component<Props> {
                     lineJoin="round"
                 />
             );
+            let learnSpeakerLabel = null;
+            if (this.props.speakers.length > 1 && points.length > 0) {
+                const labelText = (speaker.speakerName && speaker.speakerName.trim().length > 0)
+                    ? speaker.speakerName
+                    : `Speaker ${speakerIndex + 1}`;
+                const labelFontSize = this.props.fontSize;
+                const labelCharWidth = labelFontSize * 0.6;
+                const labelWidth = labelText.length * labelCharWidth;
+                const stackOffset = speakerIndex * labelFontSize * 1.4;
+                const baseLabelX = points[0].x - labelWidth / 2;
+                const baseLabelY = Math.max(
+                    points[0].y - circleRadius - labelFontSize * 1.6 - stackOffset,
+                    4
+                );
+                const labelOffsetKey = `learn-${speakerIndex}`;
+                const savedLabelOffset = (this.state as any).speakerLabelOffsets?.[labelOffsetKey] || { dx: 0, dy: 0 };
+                learnSpeakerLabel = (
+                    <Text
+                        key={`speaker-label-learn-${speakerIndex}`}
+                        x={baseLabelX + savedLabelOffset.dx}
+                        y={baseLabelY + savedLabelOffset.dy}
+                        text={labelText}
+                        fontSize={labelFontSize}
+                        fill={this.props.colorSchemes[speakerIndex].lineStrokeColor}
+                        draggable={true}
+                        onDragEnd={(e) => {
+                            const node = e.target;
+                            const newDx = node.x() - baseLabelX;
+                            const newDy = node.y() - baseLabelY;
+                            this.setState((prev: any) => ({
+                                speakerLabelOffsets: {
+                                    ...prev.speakerLabelOffsets,
+                                    [labelOffsetKey]: { dx: newDx, dy: newDy },
+                                },
+                            }));
+                        }}
+                        onMouseEnter={() => this.props.setPointerEnabled(true)}
+                        onMouseLeave={() => this.props.setPointerEnabled(false)}
+                    />
+                );
+            }
             return (
                 <Layer key={speakerIndex}>
                     {line}
                     {lineCircles}
+                    {learnSpeakerLabel}
                 </Layer>
             );
         }
@@ -244,6 +288,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
             const letterSyllables = [];
             const lines = [];
             let currLinePoints = [];
+            let firstDotCoords: { x: number; y: number } | null = null;
             for (let i = 0; i < speaker.letters.length; i++) {
                 if (speaker.letters[i].isWordSep) {
                     if (currLinePoints.length > 0) {
@@ -312,7 +357,9 @@ export default class PitchArtGeometry extends React.Component<Props> {
                 let circleStroke = this.props.colorSchemes[speakerIndex].lineStrokeColor;
     
                 if (this.props.showDynamicContent) {
-                    if (this.props.activePlayIndex === i) {
+                    const isActiveSpeaker = this.props.activePlaySpeakerIndex === -1
+                        || this.props.activePlaySpeakerIndex === speakerIndex;
+                    if (this.props.activePlayIndex === i && isActiveSpeaker) {
                         circleFill = this.props.colorSchemes[speakerIndex].activePlayColor;
                         circleStroke = this.props.colorSchemes[speakerIndex].activePlayColor;
                     } else if (speaker.letters[i].isManualPitch) {
@@ -324,6 +371,9 @@ export default class PitchArtGeometry extends React.Component<Props> {
                     }
                 }
     
+                if (firstDotCoords === null) {
+                    firstDotCoords = { x, y };
+                }
                 currLinePoints.push(x, y);
                 pointPairs.push([x, y]);
                 const isSecondaryAccent =
@@ -406,7 +456,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
             }
     
             let accentedPoint;
-    
+
             if (this.props.showAccentPitch
                 && maxPitchIndex !== null
                 && pointPairs.length >= 1) {
@@ -414,7 +464,49 @@ export default class PitchArtGeometry extends React.Component<Props> {
                     pointPairs[maxPitchIndex][0],
                     pointPairs[maxPitchIndex][1]);
             }
-    
+
+            let speakerLabel = null;
+            if (this.props.speakers.length > 1 && firstDotCoords !== null) {
+                const labelText = (speaker.speakerName && speaker.speakerName.trim().length > 0)
+                    ? speaker.speakerName
+                    : `Speaker ${speakerIndex + 1}`;
+                const labelFontSize = this.props.fontSize;
+                const labelCharWidth = labelFontSize * 0.6;
+                const labelWidth = labelText.length * labelCharWidth;
+                const stackOffset = speakerIndex * labelFontSize * 1.4;
+                const baseLabelX = firstDotCoords.x - labelWidth / 2;
+                const baseLabelY = Math.max(
+                    firstDotCoords.y - circleRadius - labelFontSize * 1.6 - stackOffset,
+                    4
+                );
+                const labelOffsetKey = `${speakerIndex}`;
+                const savedLabelOffset = (this.state as any).speakerLabelOffsets?.[labelOffsetKey] || { dx: 0, dy: 0 };
+                speakerLabel = (
+                    <Text
+                        key={`speaker-label-${speakerIndex}`}
+                        x={baseLabelX + savedLabelOffset.dx}
+                        y={baseLabelY + savedLabelOffset.dy}
+                        text={labelText}
+                        fontSize={labelFontSize}
+                        fill={this.props.colorSchemes[speakerIndex].lineStrokeColor}
+                        draggable={true}
+                        onDragEnd={(e) => {
+                            const node = e.target;
+                            const newDx = node.x() - baseLabelX;
+                            const newDy = node.y() - baseLabelY;
+                            this.setState((prev: any) => ({
+                                speakerLabelOffsets: {
+                                    ...prev.speakerLabelOffsets,
+                                    [labelOffsetKey]: { dx: newDx, dy: newDy },
+                                },
+                            }));
+                        }}
+                        onMouseEnter={() => this.props.setPointerEnabled(true)}
+                        onMouseLeave={() => this.props.setPointerEnabled(false)}
+                    />
+                );
+            }
+
             return (
                 <Layer key={speakerIndex}>
                     {accentedPoint}
@@ -423,6 +515,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
                     }
                     {lineCircles}
                     {this.props.showSyllableText ? letterSyllables : []}
+                    {speakerLabel}
                 </Layer>
             );
         }

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtGeometry.tsx
@@ -25,6 +25,8 @@ interface Props {
     showPrevPitchValueLists: boolean;
     largeCircleRadius: number;
     smallCircleRadius: number;
+    averageCircleRadius: number;
+    contourCircleRadius: number;
     graphWidth: number;
     fontSize: number;
     circleStrokeWidth: number;
@@ -220,8 +222,17 @@ export default class PitchArtGeometry extends React.Component<Props> {
         else{
             const pitches = speaker.letters.map((item) => item.pitch);
             const maxPitchIndex = pitches.indexOf(Math.max(...pitches));
-            const circleRadius = this.props.showLargeCircles ?
-                this.props.largeCircleRadius : this.props.smallCircleRadius;
+            const getLetterRadius = (letter: Letter) => {
+                if (letter && letter.isContour) return this.props.contourCircleRadius;
+                return this.props.averageCircleRadius;
+            };
+            const getLetterStrokeWidth = (radius: number) => {
+                return Math.min(this.props.circleStrokeWidth, radius * 0.6);
+            };
+            const maxLabelRadius = Math.max(
+                this.props.averageCircleRadius,
+                this.props.contourCircleRadius
+            );
             const coordConverter = converters[speakerIndex];
 
             const getAnchorXY = (letterIndex: number) => {
@@ -328,7 +339,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
                 const textOffsetKey = `${speakerIndex}-${i}`;
                 const savedOffset = (this.state as any).textOffsets?.[textOffsetKey] || { dx: 0, dy: 0 };
                 const baseTextX = x - (konvaFontSizeAsPixels * text.length / 2.0);
-                const baseTextY = y + circleRadius * 1.9;
+                const baseTextY = y + getLetterRadius(speaker.letters[i]) * 1.9;
                 letterSyllables.push(
                     <Text key={`text-${speakerIndex}-${i}`}
                           x={baseTextX + savedOffset.dx}
@@ -385,8 +396,8 @@ export default class PitchArtGeometry extends React.Component<Props> {
                                 y={y}
                                 fill={circleFill}
                                 stroke={circleStroke}
-                                strokeWidth={this.props.circleStrokeWidth}
-                                radius={circleRadius}
+                                strokeWidth={getLetterStrokeWidth(getLetterRadius(speaker.letters[i]))}
+                                radius={getLetterRadius(speaker.letters[i])}
                                 onClick={(e) => {
                                     if (e.evt.button === 2) return;
                                     this.props.playSound(currPitch);
@@ -476,7 +487,7 @@ export default class PitchArtGeometry extends React.Component<Props> {
                 const stackOffset = speakerIndex * labelFontSize * 1.4;
                 const baseLabelX = firstDotCoords.x - labelWidth / 2;
                 const baseLabelY = Math.max(
-                    firstDotCoords.y - circleRadius - labelFontSize * 1.6 - stackOffset,
+                    firstDotCoords.y - maxLabelRadius - labelFontSize * 1.6 - stackOffset,
                     4
                 );
                 const labelOffsetKey = `${speakerIndex}`;

--- a/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtLegend.tsx
+++ b/frontend/src/PitchArtWizard/PitchArtViewer/PitchArtLegend.tsx
@@ -42,12 +42,31 @@ export default class PitchArtLegend extends React.Component<PitchArtLegendProps,
         this.setState({isColorChangeDialogOpen:false});
     }
 
+    playSpeakerTones = (speakerIndex: number) => {
+        document.dispatchEvent(new CustomEvent('pitchArtPlaySpeaker', {
+            detail: { speakerIndex }
+        }));
+    }
+
     renderSpeaker = (speaker: Speaker, speakerIndex: number) => {
         const color = this.props.speakers[speakerIndex].lineColor ? this.props.speakers[speakerIndex].lineColor :  PitchArtLegend.SPEAKER_COLOR(speakerIndex);
+        const labelText = (speaker.speakerName && speaker.speakerName.trim().length > 0)
+            ? speaker.speakerName
+            : `Speaker ${speakerIndex + 1}`;
+        const hasLetters = speaker.letters && speaker.letters.length > 0;
         return (
             <div className="pitch-art-legend-list-item" key={speakerIndex}>
                 <span style={{backgroundColor: color}} className="pitch-art-legend-icon"></span>
-                <p className="pitch-art-legend-list-item-text">Speaker {speakerIndex + 1}</p>
+                <p className="pitch-art-legend-list-item-text">{labelText}</p>
+                <button
+                    className="waves-effect waves-light btn globalbtn"
+                    disabled={!hasLetters}
+                    onClick={() => this.playSpeakerTones(speakerIndex)}
+                    aria-label={`Play tones for ${labelText}`}
+                >
+                    <i className="material-icons right">play_circle_filled</i>
+                    Play Tones
+                </button>
                 <button className="waves-effect waves-light btn globalbtn" onClick={()=>{this.openColorChangeDailog(speakerIndex)}}>Change Design</button>
             </div>
         );

--- a/frontend/src/reducers/audio/reducer.tsx
+++ b/frontend/src/reducers/audio/reducer.tsx
@@ -3,7 +3,7 @@ import * as constants from "../../constants";
 import { AudioAnalysisState } from "../../store/audio/types";
 
 const defaultState: AudioAnalysisState = {
-  speakers: [{ uploadId: "", letters: [] , lineColor:"#272264", dotColor:"#0ba14a"}],
+  speakers: [{ uploadId: "", letters: [], speakerName: "", lineColor:"#272264", dotColor:"#0ba14a"}],
 };
 
 const reducer: Reducer<AudioAnalysisState> = (

--- a/frontend/src/store/audio/actions.tsx
+++ b/frontend/src/store/audio/actions.tsx
@@ -24,7 +24,7 @@ export const replaceSpeakers = (speakers: Speaker[]):
 export const addSpeaker = (): ActionReturn => (dispatch: Dispatch, getState) => {
   const speakers = getState().audio.speakers;
   const newSpeakers = update(speakers, {
-    $push: [{ uploadId: "", letters: [], speakerName: "Spearker", word: "Word", wordTranslation: "Word Translation" , lineColor:chooseColor(speakers,true),
+    $push: [{ uploadId: "", letters: [], speakerName: "", word: "Word", wordTranslation: "Word Translation" , lineColor:chooseColor(speakers,true),
   dotColor:chooseColor(speakers,false)}],
   });
   dispatch({


### PR DESCRIPTION
## Summary



- **#14a - Play tones per speaker:** Each speaker's legend entry now has its own Play Tones button: the main Play Tones plays all speakers sequentially with a short gap between them.
- **#14c - Distinct speaker names/labels in Pitch Art:** Speaker labels render in the canvas (top-right) in each speaker's line color, so multi-speaker views are readable.
- **# 15 -  Reposition Design Change menu:** On desktop (>1000px) the Pitch Art options panel sits flush to the left of the canvas:on narrow viewports it collapses into the existing popup.
- **# 16 - Initial Pitch Art rendering:** Average dots default to **Large** and contour dots to **Small** so the average pitch targets stand out. Two new dropdowns in the options menu let the user adjust average and contour dot sizes (S / M / L) independently.


