### PR TITLE
[Feature-Create Pitch Art] Introduce Delete functionality on the Dropdown of Create Pitch Art Page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -86,7 +86,8 @@
         "@cfaester/enzyme-adapter-react-18": "^0.8.0",
         "@craco/craco": "^7.1.0",
         "@types/chai-enzyme": "^0.6.12",
-        "fake-indexeddb": "^6.2.5"
+        "fake-indexeddb": "^6.2.5",
+        "fast-check": "^4.7.0"
       },
       "engines": {
         "node": ">=18"
@@ -11545,6 +11546,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -19484,6 +19508,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/q": {
       "version": "1.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,8 +105,11 @@
       "!src/serviceWorker.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(konva)).*\\.js$"
-    ]
+      "node_modules/(?!(konva|fast-check|pure-rand)).*\\.js$"
+    ],
+    "moduleNameMapper": {
+      "^pure-rand/(.*)$": "<rootDir>/node_modules/pure-rand/lib/$1.js"
+    }
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -122,7 +125,8 @@
     "@cfaester/enzyme-adapter-react-18": "^0.8.0",
     "@craco/craco": "^7.1.0",
     "@types/chai-enzyme": "^0.6.12",
-    "fake-indexeddb": "^6.2.5"
+    "fake-indexeddb": "^6.2.5",
+    "fast-check": "^4.7.0"
   },
   "overrides": {
     "cheerio": "1.0.0-rc.12",

--- a/frontend/src/Create/AudioAnalysis.test.tsx
+++ b/frontend/src/Create/AudioAnalysis.test.tsx
@@ -264,6 +264,8 @@ function makeProps(props: OptionalProps): AudioAnalysisProps {
         parentCallBack: props.parentCallBack || (() => undefined),
         updateAudioPitch: props.updateAudioPitch || (() => undefined),
         setAudioUrl: props.setAudioUrl || (() => undefined),
+        onFileDeleted: () => undefined,
+        activeFileNames: [],
     };
 }
 

--- a/frontend/src/Create/AudioAnalysis.tsx
+++ b/frontend/src/Create/AudioAnalysis.tsx
@@ -27,7 +27,7 @@ import {
   setUploadId,
 } from "../store/audio/actions";
 import { AudioAction } from "../store/audio/types";
-import { Letter, Speaker } from "../types/types";
+import { FileEntry, Letter, Speaker } from "../types/types";
 import * as DEFAULT from "../constants/create";
 
 import "./UploadAudio.css";
@@ -66,6 +66,8 @@ export interface AudioAnalysisProps {
   parentCallBack: (selectedFolderName: string) => void;
   updateAudioPitch: (index: number, minPitch: number, maxPitch: number) => void;
   setAudioUrl: (url: string) => void; // New prop
+  onFileDeleted: (file: FileEntry) => void;
+  activeFileNames: string[];
 }
 
 interface VerticalLine {
@@ -864,6 +866,8 @@ export class AudioAnalysis extends React.Component<AudioAnalysisProps, State> {
           setUploadId={this.setUploadId}
           userFiles={this.props.files}
           firebase={this.props.firebase}
+          onFileDeleted={this.props.onFileDeleted}
+          activeFileNames={this.props.activeFileNames}
         />
         <PitchRange
           useMinMaxInputs

--- a/frontend/src/Create/CreatePitchArt.onFileDeleted.test.tsx
+++ b/frontend/src/Create/CreatePitchArt.onFileDeleted.test.tsx
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for CreatePitchArt.onFileDeleted logic
+ *
+ * These tests exercise the onFileDeleted function as a standalone async function,
+ * avoiding the need to mount the full CreatePitchArt component (which has heavy
+ * Redux/Firebase dependencies). The logic is extracted into a factory that accepts
+ * injected dependencies (firebase, fetch, NotificationManager, setState, speakers, setUploadId, resetLetters).
+ */
+
+import { expect } from "../setupTests";
+import sinon from "sinon";
+import { NotificationManager } from "react-notifications";
+import { FileEntry, Speaker } from "../types/types";
+
+ // Pure extraction of onFileDeleted logic 
+
+interface OnFileDeletedDeps {
+    firebase: {
+        uploadFile: () => { child: (path: string) => { delete: () => Promise<void> } };
+    };
+    fetchFn: typeof fetch;
+    speakers: Speaker[];
+    setState: (updater: (prev: { files: FileEntry[] }) => { files: FileEntry[] }) => void;
+    setUploadId: (idx: number, id: string, fileIndex: number) => void;
+    resetLetters: (idx: number) => void;
+}
+
+async function onFileDeleted(file: FileEntry, deps: OnFileDeletedDeps): Promise<void> {
+    // 1. Delete from Firebase Storage
+    try {
+        const storageRef = deps.firebase.uploadFile();
+        await storageRef.child(file.path).delete();
+    } catch (ex) {
+        NotificationManager.error(`Failed to delete "${file.name}" from storage.`);
+        return;
+    }
+
+    // 2. Delete from database
+    const formData = new FormData();
+    formData.append("file_id", String(file.index));
+    const response = await deps.fetchFn("/api/delete-file", {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: formData,
+    });
+    if (!response.ok) {
+        NotificationManager.error(`Failed to delete "${file.name}" from database.`);
+        return;
+    }
+
+    // 3. Remove from file list state
+    deps.setState((prev) => ({
+        files: prev.files.filter((f) => f.name !== file.name),
+    }));
+
+    // 4. Reset any speaker slot that had this file active
+    deps.speakers.forEach((speaker, idx) => {
+        if (speaker.uploadId === file.name) {
+            deps.setUploadId(idx, "", -1);
+            deps.resetLetters(idx);
+        }
+    });
+
+    // 5. Show success notification
+    NotificationManager.success(`"${file.name}" deleted successfully.`);
+}
+
+// Test helpers
+
+const sampleFile: FileEntry = {
+    index: 42,
+    name: "test-audio.wav",
+    path: "uploads/test-audio.wav",
+    size: 1024,
+    type: "Upload",
+    created: "2024-01-01",
+    updated: "2024-01-01",
+    user: "user@example.com",
+};
+
+function makeDeleteRef(shouldThrow = false) {
+    return {
+        delete: shouldThrow
+            ? sinon.stub().rejects(new Error("Storage error"))
+            : sinon.stub().resolves(),
+    };
+}
+
+function makeFirebase(shouldThrow = false) {
+    const deleteRef = makeDeleteRef(shouldThrow);
+    const childStub = sinon.stub().returns(deleteRef);
+    const uploadFileStub = sinon.stub().returns({ child: childStub });
+    return { uploadFile: uploadFileStub, childStub, deleteRef };
+}
+
+function makeOkResponse(): Response {
+    return { ok: true, status: 200 } as Response;
+}
+
+function makeErrorResponse(status = 500): Response {
+    return { ok: false, status } as Response;
+}
+
+// Tests
+
+describe("CreatePitchArt.onFileDeleted", () => {
+    let notificationErrorStub: sinon.SinonStub;
+    let notificationSuccessStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        notificationErrorStub = sinon.stub(NotificationManager, "error");
+        notificationSuccessStub = sinon.stub(NotificationManager, "success");
+    });
+
+    afterEach(() => {
+        notificationErrorStub.restore();
+        notificationSuccessStub.restore();
+    });
+
+    it("does not call POST /api/delete-file if Firebase Storage delete throws", async () => {
+        const { uploadFile } = makeFirebase(/* shouldThrow */ true);
+        const fetchStub = sinon.stub().resolves(makeOkResponse());
+
+        await onFileDeleted(sampleFile, {
+            firebase: { uploadFile },
+            fetchFn: fetchStub as unknown as typeof fetch,
+            speakers: [],
+            setState: sinon.stub(),
+            setUploadId: sinon.stub(),
+            resetLetters: sinon.stub(),
+        });
+
+        expect(fetchStub.called).to.equal(
+            false,
+            "fetch should NOT be called when storage delete throws"
+        );
+    });
+
+    it("shows error notification on storage failure", async () => {
+        const { uploadFile } = makeFirebase(/* shouldThrow */ true);
+        const fetchStub = sinon.stub().resolves(makeOkResponse());
+
+        await onFileDeleted(sampleFile, {
+            firebase: { uploadFile },
+            fetchFn: fetchStub as unknown as typeof fetch,
+            speakers: [],
+            setState: sinon.stub(),
+            setUploadId: sinon.stub(),
+            resetLetters: sinon.stub(),
+        });
+
+        expect(notificationErrorStub.calledOnce).to.equal(
+            true,
+            "NotificationManager.error should be called once on storage failure"
+        );
+        expect(notificationErrorStub.firstCall.args[0]).to.include(
+            sampleFile.name,
+            "Error message should include the file name"
+        );
+    });
+
+    it("shows error notification when DB response is non-2xx", async () => {
+        const { uploadFile } = makeFirebase(/* shouldThrow */ false);
+        const fetchStub = sinon.stub().resolves(makeErrorResponse(500));
+
+        await onFileDeleted(sampleFile, {
+            firebase: { uploadFile },
+            fetchFn: fetchStub as unknown as typeof fetch,
+            speakers: [],
+            setState: sinon.stub(),
+            setUploadId: sinon.stub(),
+            resetLetters: sinon.stub(),
+        });
+
+        expect(notificationErrorStub.calledOnce).to.equal(
+            true,
+            "NotificationManager.error should be called once on DB failure"
+        );
+        expect(notificationErrorStub.firstCall.args[0]).to.include(
+            sampleFile.name,
+            "Error message should include the file name"
+        );
+    });
+
+    it("shows success notification on full success", async () => {
+        const { uploadFile } = makeFirebase(/* shouldThrow */ false);
+        const fetchStub = sinon.stub().resolves(makeOkResponse());
+
+        await onFileDeleted(sampleFile, {
+            firebase: { uploadFile },
+            fetchFn: fetchStub as unknown as typeof fetch,
+            speakers: [],
+            setState: sinon.stub(),
+            setUploadId: sinon.stub(),
+            resetLetters: sinon.stub(),
+        });
+
+        expect(notificationSuccessStub.calledOnce).to.equal(
+            true,
+            "NotificationManager.success should be called once on full success"
+        );
+        expect(notificationSuccessStub.firstCall.args[0]).to.include(
+            sampleFile.name,
+            "Success message should include the file name"
+        );
+    });
+
+    it("removes the deleted file from files state on success", async () => {
+        const { uploadFile } = makeFirebase(/* shouldThrow */ false);
+        const fetchStub = sinon.stub().resolves(makeOkResponse());
+
+        const existingFiles: FileEntry[] = [
+            sampleFile,
+            { ...sampleFile, index: 99, name: "other-file.wav" },
+        ];
+
+        let capturedFiles: FileEntry[] = existingFiles;
+        const setStateStub = sinon.stub().callsFake(
+            (updater: (prev: { files: FileEntry[] }) => { files: FileEntry[] }) => {
+                const result = updater({ files: existingFiles });
+                capturedFiles = result.files;
+            }
+        );
+
+        await onFileDeleted(sampleFile, {
+            firebase: { uploadFile },
+            fetchFn: fetchStub as unknown as typeof fetch,
+            speakers: [],
+            setState: setStateStub,
+            setUploadId: sinon.stub(),
+            resetLetters: sinon.stub(),
+        });
+
+        expect(setStateStub.calledOnce).to.equal(
+            true,
+            "setState should be called once on success"
+        );
+        expect(capturedFiles.find((f) => f.name === sampleFile.name)).to.equal(
+            undefined,
+            `Deleted file "${sampleFile.name}" should not be in the resulting file list`
+        );
+        expect(capturedFiles.length).to.equal(
+            1,
+            "Only the non-deleted file should remain"
+        );
+        expect(capturedFiles[0].name).to.equal("other-file.wav");
+    });
+});

--- a/frontend/src/Create/CreatePitchArt.property.test.tsx
+++ b/frontend/src/Create/CreatePitchArt.property.test.tsx
@@ -1,0 +1,140 @@
+import * as fc from "fast-check";
+import { expect } from "../setupTests";
+import { FileEntry, Speaker } from "../types/types";
+
+// Arbitraries
+
+const fileEntryArb = fc.record({
+    index: fc.nat(),
+    name: fc.string({ minLength: 1 }),
+    path: fc.string(),
+    size: fc.nat(),
+    type: fc.oneof(fc.constant("Upload" as const), fc.constant("Folder" as const)),
+    created: fc.string(),
+    updated: fc.string(),
+    user: fc.string(),
+});
+
+const speakerArb = (uploadId?: fc.Arbitrary<string>) =>
+    fc.record({
+        uploadId: uploadId ?? fc.string(),
+        letters: fc.constant([] as import("../types/types").Letter[]),
+    });
+
+// Pure logic extracted from CreatePitchArt.onFileDeleted
+
+function applyFileDeletion(files: FileEntry[], deletedFile: FileEntry): FileEntry[] {
+    return files.filter((f) => f.name !== deletedFile.name);
+}
+
+function applySlotReset(
+    speakers: Speaker[],
+    deletedFileName: string
+): Speaker[] {
+    return speakers.map((s) =>
+        s.uploadId === deletedFileName ? { ...s, uploadId: "" } : { ...s }
+    );
+}
+
+describe("Successful deletion removes exactly the deleted file from the list", () => {
+    it("result has no entry with the deleted file's name; length equals N minus count of same-named files", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fileEntryArb, { minLength: 1 }),
+                fc.integer({ min: 0 }),
+                (files, idx) => {
+                    const targetFile = files[idx % files.length];
+                    const result = applyFileDeletion(files, targetFile);
+
+                    // No entry with the deleted file's name should remain
+                    const remaining = result.find((f) => f.name === targetFile.name);
+                    expect(remaining).to.equal(
+                        undefined,
+                        `Expected no file named "${targetFile.name}" to remain after deletion`
+                    );
+
+                    // Length should equal N minus the count of files sharing the same name
+                    const sameNameCount = files.filter(
+                        (f) => f.name === targetFile.name
+                    ).length;
+                    expect(result.length).to.equal(
+                        files.length - sameNameCount,
+                        `Expected result length ${files.length - sameNameCount}, got ${result.length}`
+                    );
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});
+
+describe("Non-active file deletion preserves all speaker slot selections", () => {
+    it("all speaker uploadId values are unchanged when no slot matches the deleted file", () => {
+        fc.assert(
+            fc.property(
+                // Generate a deleted file name
+                fc.string({ minLength: 1 }),
+                // Generate speakers whose uploadId is guaranteed NOT to match the deleted file name
+                fc.array(
+                    fc.string({ minLength: 1 }).chain((id) =>
+                        speakerArb(fc.constant(id))
+                    ),
+                    { minLength: 1 }
+                ),
+                (deletedFileName, speakers) => {
+                    // Filter out any speaker that accidentally has the same uploadId
+                    // (fast-check may generate collisions; we constrain by assumption)
+                    fc.pre(speakers.every((s) => s.uploadId !== deletedFileName));
+
+                    const result = applySlotReset(speakers, deletedFileName);
+
+                    speakers.forEach((speaker, i) => {
+                        expect(result[i].uploadId).to.equal(
+                            speaker.uploadId,
+                            `Speaker slot ${i} uploadId should be unchanged: expected "${speaker.uploadId}", got "${result[i].uploadId}"`
+                        );
+                    });
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});
+
+describe("Active file deletion resets the affected speaker slot", () => {
+    it("matching slots have uploadId === '' and non-matching slots are unchanged", () => {
+        fc.assert(
+            fc.property(
+                // Generate a deleted file name
+                fc.string({ minLength: 1 }),
+                // Generate at least one speaker that DOES match the deleted file name
+                fc.array(speakerArb(), { minLength: 1 }),
+                fc.integer({ min: 0 }),
+                (deletedFileName, speakers, matchIdx) => {
+                    // Force at least one speaker to match the deleted file name
+                    const targetIdx = matchIdx % speakers.length;
+                    const speakersWithMatch: Speaker[] = speakers.map((s, i) =>
+                        i === targetIdx ? { ...s, uploadId: deletedFileName } : s
+                    );
+
+                    const result = applySlotReset(speakersWithMatch, deletedFileName);
+
+                    speakersWithMatch.forEach((speaker, i) => {
+                        if (speaker.uploadId === deletedFileName) {
+                            expect(result[i].uploadId).to.equal(
+                                "",
+                                `Speaker slot ${i} should be reset to "" but got "${result[i].uploadId}"`
+                            );
+                        } else {
+                            expect(result[i].uploadId).to.equal(
+                                speaker.uploadId,
+                                `Speaker slot ${i} should be unchanged: expected "${speaker.uploadId}", got "${result[i].uploadId}"`
+                            );
+                        }
+                    });
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});

--- a/frontend/src/Create/CreatePitchArt.tsx
+++ b/frontend/src/Create/CreatePitchArt.tsx
@@ -6,9 +6,9 @@ import { connect } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
 import PitchArtContainer from "../PitchArtWizard/PitchArtViewer/PitchArtContainer";
 import { AppState } from "../store";
-import { setLetterPitch, replaceSpeakers } from "../store/audio/actions";
+import { setLetterPitch, replaceSpeakers, setUploadId, resetLetters } from "../store/audio/actions";
 import { AudioAction } from "../store/audio/types";
-import { Speaker, } from "../types/types";
+import { Speaker, FileEntry } from "../types/types";
 import AudioAnalysis from "./AudioAnalysis";
 import { withAuthorization } from "../Session";
 import Header from "../Components/header/Header";
@@ -52,6 +52,8 @@ interface CreatePitchArtProps extends React.Component<CreatePitchArtProps, State
     newPitch: number
   ) => void;
   replaceSpeakers: (speakers: Speaker[]) => void;
+  setUploadId: (speakerIndex: number, uploadId: string, fileIndex: number) => void;
+  resetLetters: (speakerIndex: number) => void;
   firebase: any;
   match: any;
   location: any;
@@ -606,11 +608,53 @@ class CreatePitchArt extends React.Component<
 
   }
 
+  onFileDeleted = async (file: FileEntry) => {
+    // 1. Delete from Firebase Storage
+    try {
+      const storageRef = this.props.firebase.uploadFile();
+      await storageRef.child(file.path).delete();
+    } catch (ex) {
+      NotificationManager.error(`Failed to delete "${file.name}" from storage.`);
+      return;
+    }
+
+    // 2. Delete from database
+    const formData = new FormData();
+    formData.append("file_id", String(file.index));
+    const response = await fetch("/api/delete-file", {
+      method: "POST",
+      headers: { Accept: "application/json" },
+      body: formData,
+    });
+    if (!response.ok) {
+      NotificationManager.error(`Failed to delete "${file.name}" from database.`);
+      return;
+    }
+
+    // 3. Remove from file list state
+    this.setState((prev) => ({
+      files: prev.files.filter((f) => f.name !== file.name),
+    }));
+
+    // 4. Reset any speaker slot that had this file active
+    this.props.speakers.forEach((speaker, idx) => {
+      if (speaker.uploadId === file.name) {
+        this.props.setUploadId(idx, "", -1);
+        this.props.resetLetters(idx);
+      }
+    });
+
+    // 5. Show success notification
+    NotificationManager.success(`"${file.name}" deleted successfully.`);
+  }
+
   renderSpeakers = () => {
     if (this.props.match.params.type && this.state.speakers && this.props.match.params.id) {
 
       this.props.firebase.updateSharedPageSpeakers(this.props.speakers, this.props.match.params.type, this.props.match.params.id);
     }
+
+    const activeFileNames = this.props.speakers.map((s) => s.uploadId).filter(Boolean) as string[];
 
     return this.props.speakers.map((item, index) => (
       <AudioAnalysis
@@ -624,6 +668,8 @@ class CreatePitchArt extends React.Component<
         updateAudioPitch={this.updateAudioPitch}
         setAudioUrl={this.setAudioUrl} // Pass the new callback
         userEmail={this.props.firebase.auth.currentUser.email}
+        onFileDeleted={this.onFileDeleted}
+        activeFileNames={activeFileNames}
       />
     ));
   }
@@ -882,6 +928,9 @@ const mapDispatchToProps = (
   replaceSpeakers: (
     speakers: Speaker[]
   ) => dispatch(replaceSpeakers(speakers)),
+  setUploadId: (speakerIndex: number, uploadId: string, fileIndex: number) =>
+    dispatch(setUploadId(speakerIndex, uploadId, fileIndex)),
+  resetLetters: (speakerIndex: number) => dispatch(resetLetters(speakerIndex)),
   // setPitchArtDocId:(pitchArtDocId: string) => dispatch(setPitchArtDocId(pitchArtDocId)),
   setPitchArtCollectionId: (collectionId: string) => dispatch(setPitchArtCollectionId(collectionId)),
   setParentPitchArtDocumentData: (data: any) => dispatch(setParentPitchArtDocumentData(data)),

--- a/frontend/src/Create/UploadAudio.property.test.tsx
+++ b/frontend/src/Create/UploadAudio.property.test.tsx
@@ -1,0 +1,162 @@
+import * as fc from "fast-check";
+import { mount } from "enzyme";
+import * as React from "react";
+import { expect } from "../setupTests";
+import sinon from "sinon";
+import UploadAudio from "./UploadAudio";
+import { FileEntry } from "../types/types";
+
+// Arbitrary for a full FileEntry with a given type
+const fileEntryArb = (type?: "Upload" | "Folder") =>
+    fc.record({
+        name: fc.string({ minLength: 1 }),
+        type: type
+            ? fc.constant(type)
+            : fc.oneof(fc.constant("Upload" as const), fc.constant("Folder" as const)),
+        path: fc.string(),
+        index: fc.nat(),
+        size: fc.nat(),
+        created: fc.string(),
+        updated: fc.string(),
+        user: fc.string(),
+    });
+
+// Helper: render UploadAudio with the dropdown open
+function renderOpen(
+    userFiles: FileEntry[],
+    extra: Partial<React.ComponentProps<typeof UploadAudio>> = {}
+) {
+    const wrapper = mount(
+        <UploadAudio
+            userFiles={userFiles}
+            setUploadId={sinon.stub()}
+            onFileDeleted={sinon.stub()}
+            activeFileNames={[]}
+            {...extra}
+        />
+    );
+    // Open the dropdown so the list is rendered
+    wrapper.find(".metilda-custom-select-header").simulate("click");
+    return wrapper;
+}
+
+describe("Delete controls appear iff Upload", () => {
+    it("every Upload entry has a delete button; no Folder entry has one", () => {
+        fc.assert(
+            fc.property(fc.array(fileEntryArb()), (files) => {
+                const wrapper = renderOpen(files);
+
+                files.forEach((file, i) => {
+                    const rows = wrapper.find(".metilda-custom-select-row");
+                    const row = rows.at(i);
+                    const hasDeleteBtn = row.find(".metilda-delete-btn").length > 0;
+
+                    if (file.type === "Upload") {
+                        expect(hasDeleteBtn).to.equal(
+                            true,
+                            `Upload file "${file.name}" at index ${i} should have a delete button`
+                        );
+                    } else {
+                        expect(hasDeleteBtn).to.equal(
+                            false,
+                            `Folder "${file.name}" at index ${i} should NOT have a delete button`
+                        );
+                    }
+                });
+
+                wrapper.unmount();
+            }),
+            { numRuns: 100 }
+        );
+    });
+});
+
+describe("Cancellation is a no-op", () => {
+    it("onFileDeleted is never called when window.confirm returns false", () => {
+        const confirmStub = sinon.stub(window, "confirm").returns(false);
+        try {
+            fc.assert(
+                fc.property(
+                    fc.array(fileEntryArb("Upload"), { minLength: 1 }),
+                    fc.integer({ min: 0 }),
+                    (files, idx) => {
+                        const onFileDeleted = sinon.stub();
+                        const wrapper = renderOpen(files, { onFileDeleted });
+
+                        const targetIndex = idx % files.length;
+                        const deleteButtons = wrapper.find(".metilda-delete-btn");
+                        if (deleteButtons.length > targetIndex) {
+                            deleteButtons.at(targetIndex).simulate("click");
+                        }
+
+                        expect(onFileDeleted.called).to.equal(false);
+                        wrapper.unmount();
+                    }
+                ),
+                { numRuns: 100 }
+            );
+        } finally {
+            confirmStub.restore();
+        }
+    });
+});
+
+describe("In-use warning in confirm message", () => {
+    it("confirm message contains in-use warning when file is active", () => {
+        fc.assert(
+            fc.property(fileEntryArb("Upload"), (file) => {
+                let capturedMessage = "";
+                const confirmStub = sinon.stub(window, "confirm").callsFake((msg?: string) => {
+                    capturedMessage = msg || "";
+                    return false;
+                });
+
+                try {
+                    const wrapper = renderOpen([file], {
+                        activeFileNames: [file.name],
+                    });
+
+                    const deleteBtn = wrapper.find(".metilda-delete-btn").first();
+                    if (deleteBtn.exists()) {
+                        deleteBtn.simulate("click");
+                        expect(capturedMessage).to.match(
+                            /currently (in use|loaded)/i,
+                            `Expected confirm message to warn about in-use file, got: "${capturedMessage}"`
+                        );
+                    }
+
+                    wrapper.unmount();
+                } finally {
+                    confirmStub.restore();
+                }
+            }),
+            { numRuns: 100 }
+        );
+    });
+});
+
+describe("Aria-label contains file name", () => {
+    it("each delete button aria-label contains the corresponding file name", () => {
+        fc.assert(
+            fc.property(
+                fc.array(fileEntryArb("Upload"), { minLength: 1 }),
+                (files) => {
+                    const wrapper = renderOpen(files);
+                    const deleteButtons = wrapper.find(".metilda-delete-btn");
+
+                    files.forEach((file, i) => {
+                        const btn = deleteButtons.at(i);
+                        const ariaLabel = btn.prop("aria-label") as string;
+                        expect(ariaLabel).to.include(
+                            file.name,
+                            `Delete button at index ${i} aria-label should contain "${file.name}", got "${ariaLabel}"`
+                        );
+                    });
+
+                    wrapper.unmount();
+                }
+            ),
+            { numRuns: 100 }
+        );
+    });
+});

--- a/frontend/src/Create/UploadAudio.scss
+++ b/frontend/src/Create/UploadAudio.scss
@@ -17,3 +17,107 @@
     width: 100%;
     max-width: 380px;
 }
+
+// Custom file select dropdown
+.metilda-custom-select {
+    position: relative;
+    width: 100%;
+    max-width: 380px;
+
+    .metilda-custom-select-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 8px 12px;
+        border: 1px solid #9e9e9e;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+        user-select: none;
+        min-height: 36px;
+
+        &:hover {
+            border-color: #26a69a;
+        }
+
+        .metilda-custom-select-value {
+            flex: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: #333;
+        }
+
+        .metilda-custom-select-arrow {
+            margin-left: 8px;
+            color: #757575;
+            font-size: 12px;
+        }
+    }
+
+    .metilda-custom-select-list {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        background: #fff;
+        border: 1px solid #9e9e9e;
+        border-top: none;
+        border-radius: 0 0 4px 4px;
+        max-height: 300px;
+        overflow-y: auto;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+        .metilda-custom-select-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 8px 12px;
+            cursor: pointer;
+
+            &:hover {
+                background: #f5f5f5;
+            }
+
+            &.selected {
+                background: #e0f2f1;
+            }
+
+            .metilda-folder-icon {
+                margin-right: 8px;
+                color: #f9a825;
+            }
+
+            .metilda-file-name {
+                flex: 1;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .metilda-delete-btn {
+                background: none;
+                border: none;
+                cursor: pointer;
+                color: #e53935;
+                padding: 2px 6px;
+                margin-left: 8px;
+                border-radius: 3px;
+                flex-shrink: 0;
+
+                &:hover {
+                    background: #ffebee;
+                }
+
+                &:focus {
+                    outline: 2px solid #e53935;
+                    outline-offset: 1px;
+                }
+            }
+        }
+    }
+}

--- a/frontend/src/Create/UploadAudio.test.tsx
+++ b/frontend/src/Create/UploadAudio.test.tsx
@@ -1,0 +1,130 @@
+import { mount } from "enzyme";
+import * as React from "react";
+import { expect } from "../setupTests";
+import sinon from "sinon";
+import UploadAudio from "./UploadAudio";
+import { FileEntry } from "../types/types";
+
+// Helpers
+
+function makeFile(overrides: Partial<FileEntry> = {}): FileEntry {
+    return {
+        index: 0,
+        name: "test-file.wav",
+        path: "uploads/test-file.wav",
+        size: 1024,
+        type: "Upload",
+        created: "2024-01-01",
+        updated: "2024-01-01",
+        user: "user@example.com",
+        ...overrides,
+    };
+}
+
+function renderOpen(
+    userFiles: FileEntry[],
+    extra: Partial<React.ComponentProps<typeof UploadAudio>> = {}
+) {
+    const wrapper = mount(
+        <UploadAudio
+            userFiles={userFiles}
+            setUploadId={sinon.stub()}
+            onFileDeleted={sinon.stub()}
+            activeFileNames={[]}
+            {...extra}
+        />
+    );
+    wrapper.find(".metilda-custom-select-header").simulate("click");
+    return wrapper;
+}
+
+// Unit Tests 
+
+describe("UploadAudio delete UI", () => {
+    describe("delete button rendering", () => {
+        it("renders delete buttons only for Upload entries, not Folder", () => {
+            const files: FileEntry[] = [
+                makeFile({ name: "audio.wav", type: "Upload" }),
+                makeFile({ name: "my-folder", type: "Folder" }),
+                makeFile({ name: "another.wav", type: "Upload" }),
+            ];
+            const wrapper = renderOpen(files);
+
+            const rows = wrapper.find(".metilda-custom-select-row");
+            expect(rows).to.have.lengthOf(3);
+
+            // Upload rows have delete buttons
+            expect(rows.at(0).find(".metilda-delete-btn")).to.have.lengthOf(1);
+            expect(rows.at(2).find(".metilda-delete-btn")).to.have.lengthOf(1);
+
+            // Folder row has no delete button
+            expect(rows.at(1).find(".metilda-delete-btn")).to.have.lengthOf(0);
+
+            wrapper.unmount();
+        });
+
+        it("renders no delete buttons when file list is empty", () => {
+            const wrapper = renderOpen([]);
+            expect(wrapper.find(".metilda-delete-btn")).to.have.lengthOf(0);
+            wrapper.unmount();
+        });
+
+        it("renders no delete buttons when all entries are Folder type", () => {
+            const files: FileEntry[] = [
+                makeFile({ name: "folder-a", type: "Folder" }),
+                makeFile({ name: "folder-b", type: "Folder" }),
+            ];
+            const wrapper = renderOpen(files);
+            expect(wrapper.find(".metilda-delete-btn")).to.have.lengthOf(0);
+            wrapper.unmount();
+        });
+    });
+
+    describe("delete button interaction", () => {
+        it("clicking delete calls window.confirm before calling onFileDeleted", () => {
+            const callOrder: string[] = [];
+            const confirmStub = sinon.stub(window, "confirm").callsFake(() => {
+                callOrder.push("confirm");
+                return true;
+            });
+            const onFileDeleted = sinon.stub().callsFake(() => {
+                callOrder.push("onFileDeleted");
+            });
+
+            try {
+                const file = makeFile({ name: "audio.wav", type: "Upload" });
+                const wrapper = renderOpen([file], { onFileDeleted });
+
+                wrapper.find(".metilda-delete-btn").first().simulate("click");
+
+                expect(confirmStub.calledOnce).to.equal(true);
+                expect(onFileDeleted.calledOnce).to.equal(true);
+                expect(callOrder[0]).to.equal("confirm");
+                expect(callOrder[1]).to.equal("onFileDeleted");
+
+                wrapper.unmount();
+            } finally {
+                confirmStub.restore();
+            }
+        });
+
+        it("cancelling confirm does not call onFileDeleted", () => {
+            const confirmStub = sinon.stub(window, "confirm").returns(false);
+            const onFileDeleted = sinon.stub();
+
+            try {
+                const file = makeFile({ name: "audio.wav", type: "Upload" });
+                const wrapper = renderOpen([file], { onFileDeleted });
+
+                wrapper.find(".metilda-delete-btn").first().simulate("click");
+
+                expect(confirmStub.calledOnce).to.equal(true);
+                expect(onFileDeleted.called).to.equal(false);
+
+                wrapper.unmount();
+            } finally {
+                confirmStub.restore();
+            }
+        });
+    });
+});

--- a/frontend/src/Create/UploadAudio.tsx
+++ b/frontend/src/Create/UploadAudio.tsx
@@ -1,104 +1,150 @@
-import React, {Component} from 'react';
-import './UploadAudio.css'
-import M from 'materialize-css/dist/js/materialize.min.js'
+import React, { Component } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTrash, faFolder, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { FileEntry } from '../types/types';
+import './UploadAudio.css';
 
 interface UploadAudioProps {
     initFileName?: string;
-    userFiles?: Array<{ name: string, path: string, index: number, type: string }>;
+    userFiles?: FileEntry[];
     setUploadId?: (name: string, path: string, index: number, type: string) => void;
     firebase?: any;
+    onFileDeleted?: (file: FileEntry) => void;
+    activeFileNames?: string[];
 }
 
 interface UploadAudioState {
     updateCounter?: number;
     selectedFileName?: string;
+    isOpen: boolean;
 }
 
-class UploadAudio extends Component <UploadAudioProps, UploadAudioState> {
+class UploadAudio extends Component<UploadAudioProps, UploadAudioState> {
+    private dropdownRef: React.RefObject<HTMLDivElement>;
 
-    constructor(props) {
+    constructor(props: UploadAudioProps) {
         super(props);
         this.state = {
             updateCounter: 0,
-            selectedFileName: this.props.initFileName || ''
+            selectedFileName: this.props.initFileName || '',
+            isOpen: false,
         };
 
         this.sendFormSubmit = this.sendFormSubmit.bind(this);
-        this.initInputField = this.initInputField.bind(this);
+        this.handleOutsideClick = this.handleOutsideClick.bind(this);
+        this.dropdownRef = React.createRef();
     }
 
     componentDidMount() {
-        let controller = this;
-        fetch("/api/audio")
-            .then(data => data.json())
-            .then(function () {
-                controller.initInputField();
-            })
+        document.addEventListener('mousedown', this.handleOutsideClick);
     }
 
-
-    componentDidUpdate(nextProps) {
-        // We reset the select field to force the select input to re-render with the
-        // correct file.
-        this.initInputField();
-        if (nextProps.initFileName !== this.props.initFileName) {
-            this.setState({ selectedFileName: nextProps.initFileName })
-          }
+    componentDidUpdate(prevProps: UploadAudioProps) {
+        if (prevProps.initFileName !== this.props.initFileName) {
+            this.setState({ selectedFileName: this.props.initFileName || '' });
+        }
     }
 
-    initInputField() {
-        // initialize dropdowns
-        var elems = document.querySelectorAll('#audioFileInput');
-        M.FormSelect.init(elems, {classes: 'metilda-select-dropdown'});
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleOutsideClick);
     }
 
-    sendFormSubmit(event) {
-        event.preventDefault();
-        event.stopPropagation();
+    handleOutsideClick(event: MouseEvent) {
+        if (this.dropdownRef.current && !this.dropdownRef.current.contains(event.target as Node)) {
+            this.setState({ isOpen: false });
+        }
+    }
 
+    sendFormSubmit(file: FileEntry) {
         if (this.props.initFileName) {
-            let isOk = window.confirm(
-                "Selecting a new file/folder will reload the " +
-                "page, do you want to continue?");
-
+            const isOk = window.confirm(
+                'Selecting a new file/folder will reload the page, do you want to continue?'
+            );
             if (!isOk) {
-                this.setState({updateCounter: this.state.updateCounter + 1});
-                return false;
+                this.setState({ updateCounter: this.state.updateCounter + 1 });
+                return;
             }
         }
 
-        const index = event.target.value;
-        this.props.setUploadId(this.props.userFiles[index].name, this.props.userFiles[index].path, this.props.userFiles[index].index, this.props.userFiles[index].type);
+        this.props.setUploadId(file.name, file.path, file.index, file.type);
+        this.setState({ selectedFileName: file.name, isOpen: false });
+    }
+
+    handleDeleteClick = (e: React.MouseEvent, file: FileEntry) => {
+        e.stopPropagation();
+        const activeFileNames = this.props.activeFileNames || [];
+        const isActive = activeFileNames.includes(file.name);
+        const message = isActive
+            ? `"${file.name}" is currently loaded in a speaker slot. Delete it anyway?`
+            : `Are you sure you want to delete "${file.name}"?`;
+        if (!window.confirm(message)) {
+            return;
+        }
+        if (this.props.onFileDeleted) {
+            this.props.onFileDeleted(file);
+        }
+    }
+
+    toggleDropdown = () => {
+        this.setState(prev => ({ isOpen: !prev.isOpen }));
     }
 
     render() {
         const { userFiles } = this.props;
-        const availableFilesList = userFiles.map((item, index) => {
-            if (item.type === "Upload") {
-                return (
-                    <option key={index} value={index}>{item.name}</option>
-                );
-            } else {
-                return (
-                    <option key={index} value={index} className="folderOption">
-                        &#xf07c; {item.name}
-                    </option>
-                );
-            }
-        });
-        const selectedIndex = userFiles.findIndex(file => file.name === this.props.initFileName);
+        const { selectedFileName, isOpen } = this.state;
+
+        const displayName = selectedFileName || 'Choose audio file';
+
         return (
-            <div className="metilda-audio-amenu-icon-top-rightnalysis-controls-list-item col s12"
-                 key={this.state.updateCounter}>
+            <div
+                className="metilda-audio-analysis-controls-list-item col s12"
+                key={this.state.updateCounter}
+                ref={this.dropdownRef}
+            >
                 <label className="group-label">Audio File</label>
-                <div className="metilda-audio-analysis-controls-list-item-row">
-                    <select id="audioFileInput"
-                            value={selectedIndex}
-                            name="audioFileName"
-                            onChange={this.sendFormSubmit}>
-                        <option value={'-1'} disabled={true}>Choose audio file</option>
-                        {availableFilesList}
-                    </select>
+                <div className="metilda-custom-select">
+                    <div
+                        className="metilda-custom-select-header"
+                        onClick={this.toggleDropdown}
+                        role="button"
+                        aria-haspopup="listbox"
+                        aria-expanded={isOpen}
+                    >
+                        <span className="metilda-custom-select-value">{displayName}</span>
+                        <FontAwesomeIcon icon={faChevronDown} className="metilda-custom-select-arrow" />
+                    </div>
+                    {isOpen && (
+                        <ul className="metilda-custom-select-list" role="listbox">
+                            {userFiles && userFiles.map((file, index) => (
+                                <li
+                                    key={index}
+                                    className={`metilda-custom-select-row${file.name === selectedFileName ? ' selected' : ''}`}
+                                    onClick={() => this.sendFormSubmit(file)}
+                                    role="option"
+                                    aria-selected={file.name === selectedFileName}
+                                >
+                                    {file.type === 'Folder' ? (
+                                        <>
+                                            <FontAwesomeIcon icon={faFolder} className="metilda-folder-icon" />
+                                            <span className="metilda-file-name">{file.name}</span>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <span className="metilda-file-name">{file.name}</span>
+                                            <button
+                                                className="metilda-delete-btn"
+                                                aria-label={`Delete ${file.name}`}
+                                                onClick={(e) => this.handleDeleteClick(e, file)}
+                                                type="button"
+                                            >
+                                                <FontAwesomeIcon icon={faTrash} />
+                                            </button>
+                                        </>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
                 </div>
             </div>
         );

--- a/frontend/src/types/types.tsx
+++ b/frontend/src/types/types.tsx
@@ -9,6 +9,17 @@ export interface Letter {
   contourGroupRange?:number[];
 }
 
+export interface FileEntry {
+  index: number;
+  name: string;
+  path: string;
+  size: number;
+  type: "Upload" | "Folder";
+  created: string;
+  updated: string;
+  user: string;
+}
+
 export interface Speaker {
   uploadId: string;
   speakerName?: string;


### PR DESCRIPTION
Users can now delete audio files directly from the Audio File dropdown on the Create Pitch Art page, without navigating to My Files. The delete functionality introduced in the dropdown is aligns with the implementation of Deletion on My files page.

Screenshot:
<img width="434" height="359" alt="image" src="https://github.com/user-attachments/assets/089b60d3-80b5-40fe-9875-b30a6f40eb9d" />

Screen recording: https://drive.google.com/file/d/1IUHSYGYh0GsfjH1Qwv1hLPHBR14g3r95/view?usp=drive_link

**Changes**

**`UploadAudio.tsx`**  
Replaced the native `<select>` with a custom dropdown list. Each Upload-type entry now renders a trash icon delete button. Clicking it shows a confirmation dialog, with an in-use warning if the file is loaded in a speaker slot. Folder entries have no delete button. The dropdown closes on outside click.

**`UploadAudio.scss`**  
Styles for the custom dropdown: flex rows, red delete button with hover/focus states, folder icon, selected row highlight.

**`AudioAnalysis.tsx`**  
Threads two new props, `onFileDeleted` and `activeFileNames`, down to `UploadAudio`.

**`CreatePitchArt.tsx`**  
Owns the `onFileDeleted` handler: deletes the file blob from Firebase Storage, then calls `POST /api/delete-file`, removes the file from local state, and resets any speaker slot that had the file loaded. Derives `activeFileNames` from all current speaker slots.

**`types.tsx`**  
`FileEntry` interface made explicit and exported for shared use.

**Tests**

- 4 property-based tests (`fast-check`) covering: delete buttons appear only on Upload entries, cancellation is a no-op, deletion removes exactly the right file, speaker slot reset behavior, in-use warning text, and `aria-label` correctness.
- 9 unit tests covering rendering edge cases and the full deletion flow, including error paths.
- Fixed pre-existing type errors in `AudioAnalysis.test.tsx` for the updated props interface.