### PR TITLE
[UI Alignment] Modify the back button alignment of Choose Audio File dropdown

### DIFF
--- a/frontend/src/Create/AudioAnalysis.tsx
+++ b/frontend/src/Create/AudioAnalysis.tsx
@@ -68,6 +68,8 @@ export interface AudioAnalysisProps {
   setAudioUrl: (url: string) => void; // New prop
   onFileDeleted: (file: FileEntry) => void;
   activeFileNames: string[];
+  selectedFolderName?: string;
+  onBackClick?: () => void;
 }
 
 interface VerticalLine {
@@ -868,6 +870,8 @@ export class AudioAnalysis extends React.Component<AudioAnalysisProps, State> {
           firebase={this.props.firebase}
           onFileDeleted={this.props.onFileDeleted}
           activeFileNames={this.props.activeFileNames}
+          selectedFolderName={this.props.selectedFolderName}
+          onBackClick={this.props.onBackClick}
         />
         <PitchRange
           useMinMaxInputs

--- a/frontend/src/Create/CreatePitchArt.scss
+++ b/frontend/src/Create/CreatePitchArt.scss
@@ -273,10 +273,13 @@
   margin: 4px;
 }
 
+#metilda-drop-down-back-button {
+  display: flex;
+  align-items: flex-end;
+  padding-bottom: 4px;
+}
+
 #metilda-drop-down-back-button .audioBackButton {
-  position: relative;
-  left: 15px;
-  top: 78px;
   width: 40px;
   font-size: 14px;
   text-align: center;
@@ -286,15 +289,13 @@
   border: none;
   color: black;
   border-radius: 5px;
-  z-index: 1;
-  letter-spacing: 0.5px;
   display: block;
+  margin-right: 0px;
+  margin-left: 10px;
+  margin-top: 6px;
 }
 
 #metilda-drop-down-back-button .audioBackButtonDisabled {
-  position: relative;
-  left: 15px;
-  top: 78px;
   width: 40px;
   font-size: 14px;
   text-align: center;
@@ -304,9 +305,10 @@
   border: none;
   color: black;
   border-radius: 5px;
-  z-index: 1;
-  letter-spacing: 0.5px;
   display: block;
+  margin-right: 0px;
+  margin-left: 10px;
+  margin-top: 6px;
 }
 
 #button-drop-down-image-side-by-side {

--- a/frontend/src/Create/CreatePitchArt.tsx
+++ b/frontend/src/Create/CreatePitchArt.tsx
@@ -674,6 +674,8 @@ class CreatePitchArt extends React.Component<
         userEmail={this.props.firebase.auth.currentUser.email}
         onFileDeleted={this.onFileDeleted}
         activeFileNames={activeFileNames}
+        selectedFolderName={this.state.selectedFolderName}
+        onBackClick={this.folderBackButtonClicked}
       />
     ));
   }
@@ -875,17 +877,6 @@ class CreatePitchArt extends React.Component<
         <div className="CreatePitchArt">
           <div className="metilda-page-content">
             <div id="button-drop-down-image-side-by-side">
-              <div id="metilda-drop-down-back-button">
-                {this.state.selectedFolderName === "Uploads" ? (
-                  <button className="audioBackButtonDisabled" disabled={true}>
-                    <i className="material-icons">arrow_back</i>
-                  </button>
-                ) : (
-                  <button className="audioBackButton" onClick={() => this.folderBackButtonClicked()}>
-                    <i className="material-icons">arrow_back</i>
-                  </button>
-                )}
-              </div>
               <div id="drop-down-and-image">{this.renderSpeakers()}</div>
             </div>
             <div className="row">

--- a/frontend/src/Create/UploadAudio.scss
+++ b/frontend/src/Create/UploadAudio.scss
@@ -18,6 +18,12 @@
     max-width: 380px;
 }
 
+.upload-audio-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 1px;
+}
+
 // Custom file select dropdown
 .metilda-custom-select {
     position: relative;

--- a/frontend/src/Create/UploadAudio.tsx
+++ b/frontend/src/Create/UploadAudio.tsx
@@ -11,6 +11,8 @@ interface UploadAudioProps {
     firebase?: any;
     onFileDeleted?: (file: FileEntry) => void;
     activeFileNames?: string[];
+    selectedFolderName?: string;
+    onBackClick?: () => void;
 }
 
 interface UploadAudioState {
@@ -95,12 +97,28 @@ class UploadAudio extends Component<UploadAudioProps, UploadAudioState> {
 
         const displayName = selectedFileName || 'Choose audio file';
 
+        const { selectedFolderName, onBackClick } = this.props;
+
         return (
-            <div
-                className="metilda-audio-analysis-controls-list-item col s12"
-                key={this.state.updateCounter}
-                ref={this.dropdownRef}
-            >
+            <div className="upload-audio-wrapper">
+                {onBackClick !== undefined && (
+                    <div id="metilda-drop-down-back-button">
+                        {selectedFolderName === 'Uploads' ? (
+                            <button className="audioBackButtonDisabled" disabled={true} title="Go to parent directory">
+                                <i className="material-icons">arrow_back</i>
+                            </button>
+                        ) : (
+                            <button className="audioBackButton" onClick={onBackClick} title="Go to parent directory">
+                                <i className="material-icons">arrow_back</i>
+                            </button>
+                        )}
+                    </div>
+                )}
+                <div
+                    className="metilda-audio-analysis-controls-list-item col s12"
+                    key={this.state.updateCounter}
+                    ref={this.dropdownRef}
+                >
                 <label className="group-label">Audio File</label>
                 <div className="metilda-custom-select">
                     <div
@@ -145,6 +163,7 @@ class UploadAudio extends Component<UploadAudioProps, UploadAudioState> {
                             ))}
                         </ul>
                     )}
+                </div>
                 </div>
             </div>
         );


### PR DESCRIPTION
[UI Alignment] Modify the back button alignment of Choose Audio File dropdown

**Summary**

- Relocated #metilda-drop-down-back-button from CreatePitchArt into UploadAudio, making it a DOM sibling of the Choose audio file dropdown instead of a separate positioned element for better utilisation of space.
- Threaded selectedFolderName and onBackClick props down through AudioAnalysis → UploadAudio to support the new placement.
- Added title="Go to parent directory" tooltip to both the enabled and disabled button variants.

**Existing**
<img width="331" height="478" alt="image" src="https://github.com/user-attachments/assets/9a635f60-5d37-44d0-a314-e5b970dab25e" />

**Now**

<img width="348" height="473" alt="image" src="https://github.com/user-attachments/assets/60206313-3dcc-4198-bfa3-c08ccc0e2596" />
<img width="390" height="246" alt="image" src="https://github.com/user-attachments/assets/a530e69e-e7c5-4aff-824d-83e00e136345" />


